### PR TITLE
Application Updates

### DIFF
--- a/dist/api/BitmexAbstractAPI.d.ts
+++ b/dist/api/BitmexAbstractAPI.d.ts
@@ -1,10 +1,11 @@
-import { BitmexOptions } from '../common/BitmexOptions';
+import { BitmexOptions } from '..';
 declare type APIMethods = 'GET' | 'POST' | 'DELETE' | 'PUT';
 export declare abstract class BitmexAbstractAPI {
     abstract readonly basePath: string;
     readonly host: string;
     readonly apiKeySecret: string | null;
     readonly apiKeyID: string | null;
+    readonly hasApiKeys: boolean;
     private ratelimit;
     constructor(options?: BitmexOptions);
     private getRateLimitTimeout;
@@ -12,5 +13,6 @@ export declare abstract class BitmexAbstractAPI {
         qs?: any;
         form?: any;
     }, auth?: boolean): Promise<T>;
+    private wait;
 }
 export {};

--- a/dist/socket/BitmexAbstractSocket.d.ts
+++ b/dist/socket/BitmexAbstractSocket.d.ts
@@ -1,18 +1,23 @@
 import { ITableMessage } from './ITableMessage';
 import { BitmexObservable } from './BitmexObservable';
-import { BitmexOptions } from '../common/BitmexOptions';
+import { BitmexOptions } from '..';
 export declare abstract class BitmexAbstractSocket {
-    private tableSubject$;
-    private subscribers;
-    private subscriptions;
-    private send;
-    constructor(options?: BitmexOptions);
-    private syncSubscribers;
+    private readonly tableSubject$;
+    private readonly subscribers;
+    private readonly subscriptions;
+    private readonly webSocket;
+    private readonly closeCallback?;
+    private readonly pingWaitTime;
+    constructor(options?: BitmexOptions, pingWaitTime?: number, closeCallback?: (code: number) => void);
+    close(): void;
     protected createObservable<T>(table: string, opts?: {
         symbol?: string;
         filterKey?: number;
     }): BitmexObservable<T, ITableMessage & {
         data: T[];
     }>;
+    private createWebSocket;
+    private send;
+    private syncSubscribers;
     private messageHandler;
 }

--- a/src/api/BitmexAbstractAPI.ts
+++ b/src/api/BitmexAbstractAPI.ts
@@ -2,7 +2,7 @@ import request from 'request';
 import { parse as urlParse } from 'url';
 
 import { getAuthHeaders } from '../common/BitmexAuth';
-import { BitmexOptions } from '../common/BitmexOptions';
+import { BitmexOptions } from '..';
 
 type APIMethods = 'GET' | 'POST' | 'DELETE' | 'PUT';
 
@@ -12,6 +12,7 @@ export abstract class BitmexAbstractAPI {
     readonly host: string;
     readonly apiKeySecret: string | null;
     readonly apiKeyID: string | null;
+    readonly hasApiKeys: boolean;
 
     private ratelimit: { limit: number; remaining: number; reset: number; } | null = null;
 
@@ -21,6 +22,7 @@ export abstract class BitmexAbstractAPI {
           `${proxy}https://testnet.bitmex.com` : `${proxy}https://www.bitmex.com`;
         this.apiKeyID = options.apiKeyID || null;
         this.apiKeySecret = options.apiKeySecret || null;
+        this.hasApiKeys = !!(this.apiKeyID && this.apiKeySecret);
     }
 
     private getRateLimitTimeout() {
@@ -35,7 +37,7 @@ export abstract class BitmexAbstractAPI {
         const url = `${ this.host }${this.basePath}${endpoint}`;
         const path = urlParse(url).pathname || '';
 
-        const headers = auth ? getAuthHeaders({
+        const headers = (auth || this.hasApiKeys) ? getAuthHeaders({
             apiKeyID: this.apiKeyID,
             apiKeySecret: this.apiKeySecret,
             method,
@@ -52,22 +54,35 @@ export abstract class BitmexAbstractAPI {
         };
 
         const timeout = this.getRateLimitTimeout();
+        await this.wait(timeout);
         return new Promise<T>((resolve, reject) => {
-            setTimeout(() => {
-                request(options, (error, response, body) => {
-                    if (error) { return reject(error); }
+            request(options, (error, response, body) => {
+                if (error) { return reject(error); }
 
-                    this.ratelimit = {
-                        limit: parseInt(<string>response.headers['x-ratelimit-limit'], 10),
-                        remaining: parseInt(<string>response.headers['x-ratelimit-remaining'], 10),
-                        reset: parseInt(<string>response.headers['x-ratelimit-reset'], 10) * 1000
-                    };
+                this.ratelimit = {
+                    limit: parseInt(<string>response.headers['x-ratelimit-limit'], 10),
+                    remaining: parseInt(<string>response.headers['x-ratelimit-remaining'], 10),
+                    reset: parseInt(<string>response.headers['x-ratelimit-reset'], 10) * 1000
+                };
 
-                    if (body.error) { return reject(body.error); }
+                if (body.error) { return reject(body.error); }
 
-                    resolve(body);
-                });
-            }, timeout);
+                resolve(body);
+            });
         });
+    }
+
+    private wait(time: number) {
+        // Only use setTimeout if needed to prevent a 10ms delay from NodeJS.
+        if (time) {
+            return new Promise((resolve) => {
+                setTimeout(() => {
+                    resolve();
+                }, time);
+            });
+        } else {
+            return Promise.resolve();
+        }
+
     }
 }


### PR DESCRIPTION
Hi,
I have created a PR to pass along some (what I would consider) important updates to this package. 

Current Issues:
- With the HTTP API, Auth headers are not passed reducing the quantity of requests I can make to unauthenticated endpoints by half.
- Additionally, upon inspection of the code, I found the use of `setTimeout` before a request is invoked. This will delay any request by 10ms minimum and doesn't always happen. 
- I have still received 429s using this package. Therefore, I am unsure if the timeout functionality is working correctly, however, that is not addressed in this PR.

- With the WS API, it is a known issue that BitMEX will close websockets when many trades take place. There is no listener appended to the websocket to detect when the connection is closed. 

Fixes: 
- Always pass auth headers if they are present.
- Only use `setTimeout` if necessary
- Allow users to pass custom delay for ping
- Use more efficient `refresh()` method for ping timeout
- Allow users to pass callback listener for websocket `close` event 

I tested the code, but didn't create any tests since none existed previously. I figure that falls outside the scope of this PR. 